### PR TITLE
fixed user links to now point to correct user

### DIFF
--- a/BOSSYUI.md
+++ b/BOSSYUI.md
@@ -1,3 +1,3 @@
 - Aaron Shaffer, [username](https://github.com/ClassicSours)
-- Oliver Wong, [username](https://github.com/Mriewer)
-- Michael Riewer, [username](https://github.com/oliverrayreed)
+- Oliver Wong, [username](https://github.com/oliverrayreed)
+- Michael Riewer, [username](https://github.com/Mriewer)


### PR DESCRIPTION
had the wrong username links for my group members